### PR TITLE
 Finish feature implementation and fix the bug

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
@@ -41,6 +41,17 @@
 	<a component="topic/mark-unread-for-all" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-inbox text-secondary"></i> [[topic:thread-tools.markAsUnreadForAll]]</a>
 </li>
 
+
+
+
+<li class="dropdown-divider"></li>
+{{{ end }}}
+
+{{{ if privileges.deletable }}}
+<li {{{ if deleted }}}hidden{{{ end }}}>
+	<a component="topic/delete" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete]]</a>
+</li>
+
 <li {{{ if private }}}hidden{{{ end }}}>
 	<a component="topic/make-private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
 		<i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.makePrivate]]
@@ -51,15 +62,6 @@
 	<a component="topic/make-public" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
 		<i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.makePublic]]
 	</a>
-</li>
-
-
-<li class="dropdown-divider"></li>
-{{{ end }}}
-
-{{{ if privileges.deletable }}}
-<li {{{ if deleted }}}hidden{{{ end }}}>
-	<a component="topic/delete" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete]]</a>
 </li>
 
 {{{ if !scheduled }}}

--- a/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/topic-menu-list.tpl
@@ -52,18 +52,6 @@
 	<a component="topic/delete" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete]]</a>
 </li>
 
-<li {{{ if private }}}hidden{{{ end }}}>
-	<a component="topic/make-private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
-		<i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.makePrivate]]
-	</a>
-</li>
-
-<li {{{ if !private }}}hidden{{{ end }}}>
-	<a component="topic/make-public" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
-		<i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.makePublic]]
-	</a>
-</li>
-
 {{{ if !scheduled }}}
 <li {{{ if !deleted }}}hidden{{{ end }}}>
 	<a component="topic/restore" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-history text-secondary"></i> [[topic:thread-tools.restore]]</a>
@@ -78,6 +66,17 @@
 {{{ if privileges.isAdminOrMod }}}
 <li>
 	<a component="topic/delete/posts" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete-posts]]</a>
+</li>
+<li {{{ if private }}}hidden{{{ end }}}>
+	<a component="topic/make-private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
+		<i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.makePrivate]]
+	</a>
+</li>
+
+<li {{{ if !private }}}hidden{{{ end }}}>
+	<a component="topic/make-public" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2">
+		<i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.makePublic]]
+	</a>
 </li>
 {{{ end }}}
 

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -17,7 +17,6 @@ define('forum/topic/events', [
 	function onTopicPrivate(data) {
 		threadTools.setPrivateState({ ...data, isPrivate: true });
 	}
-	
 	function onTopicPublic(data) {
 		threadTools.setPrivateState({ ...data, isPrivate: false });
 	}
@@ -35,7 +34,7 @@ define('forum/topic/events', [
 		'event:topic_unlocked': threadTools.setLockedState,
 
 		'event:topic_made_private': onTopicPrivate,
-  		'event:topic_made_public': onTopicPublic,
+		'event:topic_made_public': onTopicPublic,
 
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -305,20 +305,12 @@ define('forum/topic/threadTools', [
 
 	ThreadTools.setPrivateState = function (data) {
 		const threadEl = components.get('topic');
-		// 1. 如果前端当前 topic 不是 data.tid，忽略
 		if (parseInt(data.tid, 10) !== parseInt(threadEl.attr('data-tid'), 10)) {
 			return;
 		}
-	
-		// 2. 判断 isPrivate
-		//    假设你也想结合权限，例如不让普通用户看到某些东西，可以像 isLocked 那样加判断
-		//    const isPrivate = data.isPrivate && !ajaxify.data.privileges.isAdminOrMod;
 		const isPrivate = !!data.isPrivate;
 		console.log(data);
 	
-		// 3. 切换按钮
-		//    （与锁定逻辑中 toggleClass('hidden', data.isLocked) 类似）
-		//    假设 "topic/make-private" / "topic/make-public" 是你的按钮 component
 		components.get('topic/make-private')
 			.toggleClass('hidden', isPrivate)
 			.parent().attr('hidden', isPrivate ? '' : null);
@@ -326,24 +318,17 @@ define('forum/topic/threadTools', [
 			.toggleClass('hidden', !isPrivate)
 			.parent().attr('hidden', !isPrivate ? '' : null);
 	
-		// 4. 如果私有时，需要隐藏“回复”、或者让访问者必须是管理员？
-		//    看你需求，类似 setLockedState 里:
 		const hideReply = !!(isPrivate && !ajaxify.data.privileges.isAdminOrMod && /* 自定义判断 */ false);
 	
-		// 假设要隐藏“回复区”
 		components.get('topic/reply/container').toggleClass('hidden', hideReply);
-		// 还可以隐藏帖子里的“回复/引用”等
 		threadEl
 			.find('[component="post"]:not(.deleted) [component="post/reply"], [component="post"]:not(.deleted) [component="post/quote"]')
 			.toggleClass('hidden', hideReply);
 	
-		// 5. 如果要给主题加一个 "private" 标签（模仿锁的🔒图标）
 		$('[component="topic/labels"] [component="topic/private"]').toggleClass('hidden', !isPrivate);
 	
-		// 6. 更新前端数据
 		ajaxify.data.private = isPrivate;
 	
-		// 7. 插入事件时间线
 		if (data.events) {
 			require(['forum/topic/posts'], function (posts) {
 				posts.addTopicEvents(data.events);

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -55,13 +55,10 @@ define('forum/topic/threadTools', [
 			topicCommand('put', '/private', 'makePrivate');
 			return false;
 		});
-		
 		topicContainer.on('click', '[component="topic/make-public"]', function () {
 			topicCommand('del', '/private', 'makePublic');
 			return false;
 		});
-		
-
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
@@ -310,32 +307,17 @@ define('forum/topic/threadTools', [
 		}
 		const isPrivate = !!data.isPrivate;
 		console.log(data);
-	
-		components.get('topic/make-private')
-			.toggleClass('hidden', isPrivate)
-			.parent().attr('hidden', isPrivate ? '' : null);
-		components.get('topic/make-public')
-			.toggleClass('hidden', !isPrivate)
-			.parent().attr('hidden', !isPrivate ? '' : null);
-	
-		const hideReply = !!(isPrivate && !ajaxify.data.privileges.isAdminOrMod && /* 自定义判断 */ false);
-	
+		components.get('topic/make-private').toggleClass('hidden', isPrivate).parent().attr('hidden', isPrivate ? '' : null);
+		components.get('topic/make-public').toggleClass('hidden', !isPrivate).parent().attr('hidden', !isPrivate ? '' : null);
+		const hideReply = !!(isPrivate && !ajaxify.data.privileges.isAdminOrMod && false);
 		components.get('topic/reply/container').toggleClass('hidden', hideReply);
-		threadEl
-			.find('[component="post"]:not(.deleted) [component="post/reply"], [component="post"]:not(.deleted) [component="post/quote"]')
-			.toggleClass('hidden', hideReply);
-	
+		threadEl.find('[component="post"]:not(.deleted) [component="post/reply"], [component="post"]:not(.deleted) [component="post/quote"]').toggleClass('hidden', hideReply);
 		$('[component="topic/labels"] [component="topic/private"]').toggleClass('hidden', !isPrivate);
-	
 		ajaxify.data.private = isPrivate;
-	
 		if (data.events) {
-			require(['forum/topic/posts'], function (posts) {
-				posts.addTopicEvents(data.events);
-			});
+			require(['forum/topic/posts'], function (posts) { posts.addTopicEvents(data.events); });
 		}
 	};
-	
 
 	ThreadTools.setLockedState = function (data) {
 		const threadEl = components.get('topic');
@@ -344,7 +326,6 @@ define('forum/topic/threadTools', [
 		}
 
 		const isLocked = data.isLocked && !ajaxify.data.privileges.isAdminOrMod;
-
 		components.get('topic/lock').toggleClass('hidden', data.isLocked).parent().attr('hidden', data.isLocked ? '' : null);
 		components.get('topic/unlock').toggleClass('hidden', !data.isLocked).parent().attr('hidden', !data.isLocked ? '' : null);
 

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -163,16 +163,14 @@ topicsAPI.unlock = async function (caller, data) {
 
 topicsAPI.makePrivate = async (caller, data) => {
 	await doTopicAction('makePrivate', 'event:topic_made_private', caller, {
-	  tids: [ data.tid ],
+		tids: data.tid,
 	});
-  };
-  
-  topicsAPI.makePublic = async (caller, data) => {
+};
+topicsAPI.makePublic = async (caller, data) => {
 	await doTopicAction('makePublic', 'event:topic_made_public', caller, {
-	  tids: [ data.tid ],
+		tids: data.tid,
 	});
-  };
-  
+};
 
 topicsAPI.follow = async function (caller, data) {
 	await topics.follow(data.tid, caller.uid);

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -162,11 +162,16 @@ topicsAPI.unlock = async function (caller, data) {
 };
 
 topicsAPI.makePrivate = async (caller, data) => {
+	const currentTags = await topics.getTopicTags(data.tid);
+	currentTags.push('privatepost');
+	topicsAPI.updateTags(caller, { tid: data.tid, tags: currentTags }, true);
 	await doTopicAction('makePrivate', 'event:topic_made_private', caller, {
 		tids: data.tid,
 	});
 };
 topicsAPI.makePublic = async (caller, data) => {
+	const currentTags = await topics.getTopicTags(data.tid);
+	topicsAPI.updateTags(caller, { tid: data.tid, tags: currentTags.filter(e => e !== 'privatepost') }, true);
 	await doTopicAction('makePublic', 'event:topic_made_public', caller, {
 		tids: data.tid,
 	});
@@ -184,8 +189,8 @@ topicsAPI.unfollow = async function (caller, data) {
 	await topics.unfollow(data.tid, caller.uid);
 };
 
-topicsAPI.updateTags = async (caller, { tid, tags }) => {
-	if (!await privileges.topics.canEdit(tid, caller.uid)) {
+topicsAPI.updateTags = async (caller, { tid, tags }, from_private = false) => {
+	if (!await privileges.topics.canEdit(tid, caller.uid) && !from_private) {
 		throw new Error('[[error:no-privileges]]');
 	}
 
@@ -199,7 +204,6 @@ topicsAPI.addTags = async (caller, { tid, tags }) => {
 	if (!await privileges.topics.canEdit(tid, caller.uid)) {
 		throw new Error('[[error:no-privileges]]');
 	}
-
 	const cid = await topics.getTopicField(tid, 'cid');
 	await topics.validateTags(tags, cid, caller.uid, tid);
 	tags = await topics.filterTags(tags, cid);

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -23,14 +23,12 @@ module.exports = function (Categories) {
 		topics.calculateTopicIndices(topicsData, data.start);
 
 		const userPrivileges = await privileges.categories.get(data.cid, data.uid);
-		const isAdminOrMod = userPrivileges.isAdminOrMod;
-
-		topicsData = topicsData.filter(topic => {
+		topicsData = topicsData.filter((topic) => {
 			if (parseInt(topic.private, 10) !== 1) {
 				return true;
 			}
 			const isOwner = parseInt(topic.uid, 10) === parseInt(data.uid, 10);
-			return (isOwner || isAdminOrMod);
+			return (isOwner || userPrivileges.isAdminOrMod);
 		});
 
 		if (!topicsData.length) {
@@ -49,9 +47,7 @@ module.exports = function (Categories) {
 			topics: results.topics,
 			nextStart: data.stop + 1,
 		};
-		
 	};
-
 	Categories.getTopicIds = async function (data) {
 		const [pinnedTids, set] = await Promise.all([
 			Categories.getPinnedTids({ ...data, start: 0, stop: -1 }),

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -86,17 +86,15 @@ Topics.unlock = async (req, res) => {
 };
 
 Topics.makePrivate = async (req, res) => {
-	const tid = req.params.tid;
-	await api.topics.makePrivate(req, { tid: tid });
+	await api.topics.makePrivate(req, { tid: [req.params.tid] });
 	helpers.formatApiResponse(200, res);
-  };
-  
+};
+
 Topics.makePublic = async (req, res) => {
-	const tid = req.params.tid;
-	await api.topics.makePublic(req, { tid: tid });
+	await api.topics.makePublic(req, { tid: [req.params.tid] });
 	helpers.formatApiResponse(200, res);
-  };
-  
+};
+
 
 Topics.follow = async (req, res) => {
 	await api.topics.follow(req, req.params);

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -37,11 +37,11 @@ privsTopics.get = async function (tid, uid) {
 	const mayReply = privsTopics.canViewDeletedScheduled(topicData, {}, false, privData['topics:schedule']);
 
 	const privateVal = topicData.private ? parseInt(topicData.private, 10) : 0;
-	const canRead = true
+	let canRead = true;
 	if (privateVal === 1) {
-	  if (!isOwner && !isAdminOrMod) {
-		canRead = false;
-	  }
+		if (!isOwner && !isAdminOrMod) {
+			canRead = false;
+		}
 	}
 
 	return await plugins.hooks.fire('filter:privileges.topics.get', {
@@ -58,7 +58,6 @@ privsTopics.get = async function (tid, uid) {
 		'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
 		read: canRead,
 		purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
-	
 		view_thread_tools: editable || deletable,
 		editable,
 		deletable,
@@ -68,7 +67,7 @@ privsTopics.get = async function (tid, uid) {
 		disabled,
 		tid,
 		uid,
-	  });
+	});
 };
 
 privsTopics.can = async function (privilege, tid, uid) {
@@ -80,7 +79,7 @@ privsTopics.filterTids = async function (privilege, tids, uid) {
 	if (!Array.isArray(tids) || !tids.length) {
 		return [];
 	}
-	
+
 	const topicsData = await topics.getTopicsFields(tids, ['tid', 'cid', 'deleted', 'scheduled', 'private', 'uid']);
 	const cids = _.uniq(topicsData.map(topic => topic.cid));
 	const results = await privsCategories.getBase(privilege, cids, uid);
@@ -94,20 +93,23 @@ privsTopics.filterTids = async function (privilege, tids, uid) {
 	const canViewDeleted = _.zipObject(cids, results.view_deleted);
 	const canViewScheduled = _.zipObject(cids, results.view_scheduled);
 
-	const filteredTids = topicsData.filter(t => {
+	const filteredTids = topicsData.filter((t) => {
 		if (!cidsSet.has(t.cid)) {
 			return false;
 		}
-		const canView = (results.isAdmin || privsTopics.canViewDeletedScheduled(t, {}, canViewDeleted[t.cid], canViewScheduled[t.cid]));
+		const canView = (results.isAdmin || privsTopics.canViewDeletedScheduled(t,
+			{},
+			canViewDeleted[t.cid],
+			canViewScheduled[t.cid]));
 		if (!canView) {
 			return false;
 		}
-		
+
 		const privateVal = t.private ? parseInt(t.private, 10) : 0;
 		if (privateVal === 1) {
-		const isOwner = parseInt(t.uid, 10) === parseInt(uid, 10);
-		if (!isOwner && !results.isAdmin) {
-			return false;
+			const isOwner = parseInt(t.uid, 10) === parseInt(uid, 10);
+			if (!isOwner && !results.isAdmin) {
+				return false;
 			}
 		}
 		return true;

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -72,16 +72,13 @@ Events._types = {
 
 Events._types.makePrivate = {
 	icon: 'fa-eye-slash',
-	translation: async (event, language) => {
-	  return await translateSimple(event, language, 'topic:user-make-topic-private');
-	},
-  };
-  Events._types.makePublic = {
+	translation: async (event, language) => await translateSimple(event, language, 'topic:user-make-topic-private'),
+};
+
+Events._types.makePublic = {
 	icon: 'fa-eye',
-	translation: async (event, language) => {
-	  return await translateSimple(event, language, 'topic:user-make-topic-public');
-	},
-  };
+	translation: async (event, language) => await translateSimple(event, language, 'topic:user-make-topic-public'),
+};
 
 Events.init = async () => {
 	// Allow plugins to define additional topic event types

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -73,8 +73,6 @@ Events._types = {
 Events._types.makePrivate = {
 	icon: 'fa-eye-slash',
 	translation: async (event, language) => {
-	  // 这个函数里可使用上面写好的 translateSimple/translateEventArgs
-	  // 显示"用户将主题设为私有"的翻译
 	  return await translateSimple(event, language, 'topic:user-make-topic-private');
 	},
   };

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -44,7 +44,7 @@ module.exports = function (Topics) {
 		const data = await plugins.hooks.fire(`filter:topic.${hook}`, { topicData: topicData, uid: uid, isDelete: isDelete, canDelete: canDelete, canRestore: canDelete });
 
 		validateData(data.canDelete, data.isDelete, data.canRestore);
-		
+
 		if (data.topicData.deleted && data.isDelete) {
 			throw new Error('[[error:topic-already-deleted]]');
 		} else if (!data.topicData.deleted && !data.isDelete) {
@@ -118,38 +118,33 @@ module.exports = function (Topics) {
 	topicTools.makePrivate = async function (tid, uid) {
 		return await togglePrivate(tid, uid, true);
 	};
-	
+
 	topicTools.makePublic = async function (tid, uid) {
 		return await togglePrivate(tid, uid, false);
 	};
-	
+
 	async function togglePrivate(tid, uid, isPrivate) {
 		const topicData = await Topics.getTopicFields(tid, ['tid', 'uid', 'cid', 'private']);
 		if (!topicData) {
 			throw new Error('[[error:no-topic]]');
 		}
-	
+
 		const isAdminOrMod = await privileges.categories.isAdminOrMod(topicData.cid, uid);
 		const isOwner = parseInt(topicData.uid, 10) === parseInt(uid, 10);
 
 		if (!isOwner && !isAdminOrMod) {
-		throw new Error('[[error:no-privileges]]');
+			throw new Error('[[error:no-privileges]]');
 		}
-
-	
 		await Topics.setTopicField(tid, 'private', isPrivate ? 1 : 0);
-		console.log("src/topics/tool.js togglePrivate")
-		console.log(await Topics.getTopicField(tid, 'private'));
-	
 		topicData.events = await Topics.events.log(tid, {
 			type: isPrivate ? 'makePrivate' : 'makePublic',
 			uid: uid,
 		});
-	
+
 		topicData.private = isPrivate ? 1 : 0;
 		return topicData;
 	}
-	
+
 
 	topicTools.pin = async function (tid, uid) {
 		return await togglePin(tid, uid, true);

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -124,32 +124,28 @@ module.exports = function (Topics) {
 	};
 	
 	async function togglePrivate(tid, uid, isPrivate) {
-		// 1. 获取主题数据
 		const topicData = await Topics.getTopicFields(tid, ['tid', 'uid', 'cid', 'private']);
 		if (!topicData) {
 			throw new Error('[[error:no-topic]]');
 		}
 	
-		// 2. 权限检查
-		//    - 你可直接判断 if (!isAdminOrMod) throw new Error('[[error:no-privileges]]')
-		//      或者做更细的判断，比如只有作者和管理员能 make private...
 		const isAdminOrMod = await privileges.categories.isAdminOrMod(topicData.cid, uid);
-		if (!isAdminOrMod) {
-			throw new Error('[[error:no-privileges]]');
+		const isOwner = parseInt(topicData.uid, 10) === parseInt(uid, 10);
+
+		if (!isOwner && !isAdminOrMod) {
+		throw new Error('[[error:no-privileges]]');
 		}
+
 	
-		// 3. 写数据库: `private=1` or `private=0`
 		await Topics.setTopicField(tid, 'private', isPrivate ? 1 : 0);
+		console.log("src/topics/tool.js togglePrivate")
+		console.log(await Topics.getTopicField(tid, 'private'));
 	
-		// 4. 在 topicEvent 中留下记录
-		//    type 可以是 'makePrivate' 或 'makePublic'，这里要注意
-		//    由 doTopicAction() 会自动根据我们传进去的 type 来做
 		topicData.events = await Topics.events.log(tid, {
 			type: isPrivate ? 'makePrivate' : 'makePublic',
 			uid: uid,
 		});
 	
-		// 5. 返回给上层
 		topicData.private = isPrivate ? 1 : 0;
 		return topicData;
 	}


### PR DESCRIPTION
The feature is implemented with following characteristics:

Both the Admin user and the user who created the topic can make the topic private (make private) or public (make public). At the same time, Admin users can view all private topics, regardless of whether they created the topic or not. Ordinary users or users who are not logged in cannot view private topics that they did not create.

If an Admin user makes a topic private that was created by a regular user, the regular user can still access the topic.

UPDATE: lint style error is fixed. the code coverage is acceptable.
UPDATE: private post tag is implemented.