### PR TITLE
[Enhancement] Improve the endorsement tag feature that it can recognized any admin user

### DIFF
--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -190,18 +190,18 @@ module.exports = function (Posts) {
 			await db.sortedSetAdd(`uid:${uid}:downvote`, now, pid);
 		}
 		// If uid = admin, then add a tag that said admin endorsed.
-		if (uid === 1 && type === 'upvote' && !unvote) {
+		if (user.isAdministrator(uid) && type === 'upvote' && !unvote) {
 			let postContent = await Posts.getPostField(pid, 'content') || '';
 			postContent += '\n\n**✅ Admin endorsed this post**';
 			const editResult = await Posts.edit({
 				pid: pid,
 				content: postContent,
-				uid: 1,
+				uid: uid,
 			});
 			if (!editResult.post.deleted) {
 				websockets.in(`topic_${editResult.topic.tid}`).emit('event:post_edited', editResult);
 			}
-		} else if (uid === 1 && unvote) {
+		} else if (user.isAdministrator(uid) && unvote) {
 			let postContent = await Posts.getPostField(pid, 'content') || '';
 			const tag = '\n\n**✅ Admin endorsed this post**';
 			if (postContent.endsWith(tag)) {
@@ -209,7 +209,7 @@ module.exports = function (Posts) {
 				const editResult = await Posts.edit({
 					pid: pid,
 					content: postContent,
-					uid: 1,
+					uid: uid,
 				});
 				if (!editResult.post.deleted) {
 					websockets.in(`topic_${editResult.topic.tid}`).emit('event:post_edited', editResult);


### PR DESCRIPTION
After deploying the VM server, we realized that there can be multiply admin users such that our original code becomes unsuitable. Because the original code only does if-case whether the user id equal to 1. Now it can call an internal method `user.isAdministrator(uid)` to determine whether or not the user is an admin or not.

I performed automated tests and manually interacted with the GUI to ensure our change wouldn't result in disruption.