### PR TITLE
Update index.js to make the error message dissapear during the npm test.

### DIFF
--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -13,7 +13,7 @@ translatorApi.translate = async function (postData) {
 		console.log(data);
 		return [data.is_english, data.translated_content];
 	} catch (error) {
-		console.error('Translation fetch error:', error);
+		console.log('Translation failed to fetch');
 		return [true, postData.content];
 	}
 };


### PR DESCRIPTION
Previously, we have 5000+ lines of error message when running npm test. Now, we changed it into a print statement with "console.log". Which may solve the problem, and reduce the amount of error message.